### PR TITLE
add aria-describedby to date inputs so that they can point to feedback

### DIFF
--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -151,7 +151,6 @@ class DateRangePickerWrapper extends React.Component {
       <div>
         <DateRangePicker
           {...props}
-          ariaDescribedBy="input-feedback"
           onDatesChange={this.onDatesChange}
           onFocusChange={this.onFocusChange}
           focusedInput={focusedInput}

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -151,6 +151,7 @@ class DateRangePickerWrapper extends React.Component {
       <div>
         <DateRangePicker
           {...props}
+          ariaDescribedBy="input-feedback"
           onDatesChange={this.onDatesChange}
           onFocusChange={this.onFocusChange}
           focusedInput={focusedInput}

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -28,6 +28,7 @@ const propTypes = forbidExtraProps({
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   displayValue: PropTypes.string,
+  ariaDescribedBy: PropTypes.string,
   ariaLabel: PropTypes.string,
   autoComplete: PropTypes.string,
   titleText: PropTypes.string,
@@ -178,6 +179,7 @@ class DateInput extends React.PureComponent {
     const {
       id,
       placeholder,
+      ariaDescribedBy,
       ariaLabel,
       autoComplete,
       titleText,
@@ -242,7 +244,7 @@ class DateInput extends React.PureComponent {
           disabled={disabled}
           readOnly={typeof readOnly === 'boolean' ? readOnly : isTouch}
           required={required}
-          aria-describedby={screenReaderMessage && screenReaderMessageId}
+          aria-describedby={`${screenReaderMessage && screenReaderMessageId} ${ariaDescribedBy?ariaDescribedBy:''}`}
           aria-expanded={isFocused}
         />
 

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -241,6 +241,7 @@ function DateRangePickerInput({
         id={startDateId}
         placeholder={startDatePlaceholderText}
         ariaLabel={startDateAriaLabel}
+        ariaDescribedBy={ariaDescribedBy}
         autoComplete={autoComplete}
         titleText={startDateTitleText}
         displayValue={startDate}
@@ -277,6 +278,7 @@ function DateRangePickerInput({
       <DateInput
         id={endDateId}
         placeholder={endDatePlaceholderText}
+        ariaDescribedBy={ariaDescribedBy}
         ariaLabel={endDateAriaLabel}
         autoComplete={autoComplete}
         titleText={endDateTitleText}


### PR DESCRIPTION
This is a change to add aria-describedby attribute to the DateInputs used in the DateRangePicker component.